### PR TITLE
🔧  refactor: Update rival register api/#12

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 
 const userSchema = new mongoose.Schema({
-    nickname: { type: String, required: true, unique: true },
+    nickName: { type: String, required: true, unique: true },
     email: { type: String, required: true, unique: true },
     password: { type: String, required: true },
     baekjoonTier: { type: String, required: true },

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -24,7 +24,7 @@ const jwt = require('jsonwebtoken');
  *           schema:
  *             type: object
  *             properties:
- *               nickname:
+ *               nickName:
  *                 type: string
  *                 description: 사용자의 닉네임
  *                 example: 'example_nickname'
@@ -63,10 +63,9 @@ const jwt = require('jsonwebtoken');
  *                   example: "서버 에러"
  */
 router.post('/signup', async (req, res) => {
-    const { nickname, email, password, baekjoonTier } = req.body;
-
+    const { nickName, email, password, baekjoonTier } = req.body;
     try {
-        const newUser = new User({ nickname, email, password, baekjoonTier });
+        const newUser = new User({ nickName, email, password, baekjoonTier });
         await newUser.save();
 
         res.status(201).json({ message: '성공적으로 회원가입이 완료되었습니다!' });

--- a/src/routes/rivalRoutes.js
+++ b/src/routes/rivalRoutes.js
@@ -109,4 +109,29 @@ router.post('/register', async (req, res) => {
     }
 });
 
+router.delete('/remove', async (req, res) => {
+    const { userEmail, rivalNickName } = req.query;
+
+    try {
+        const user = await User.findOne({ email: userEmail });
+        const rival = await User.findOne({ nickname: rivalNickName });
+
+        if (!user || !rival) return res.status(404).json({ message: '유저를 찾을 수 없습니다.' });
+
+        const userRivalIndex = user.rivals.indexOf(rival.email);
+        const rivalUserIndex = rival.rivals.indexOf(user.email);
+
+        if (userRivalIndex > -1) user.rivals.splice(userRivalIndex, 1);
+        if (rivalUserIndex > -1) rival.rivals.splice(rivalUserIndex, 1);
+
+        await user.save();
+        await rival.save();
+
+        res.status(200).json({ message: '라이벌 삭제 성공!', userRivals: user.rivals });
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: '서버 에러' });
+    }
+});
+
 module.exports = router;

--- a/src/routes/rivalRoutes.js
+++ b/src/routes/rivalRoutes.js
@@ -30,7 +30,7 @@ const User = require('../models/User');
  *               rivalNickName:
  *                 type: string
  *                 description: 등록할 라이벌의 닉네임
- *                 example: 'rivalNick'
+ *                 example: 'rivalNickname'
  *     responses:
  *       200:
  *         description: 라이벌 등록 성공
@@ -47,6 +47,16 @@ const User = require('../models/User');
  *                   items:
  *                     type: string
  *                     example: 'rival@example.com'
+ *       400:
+ *         description: 이미 등록된 라이벌
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: '이미 등록된 라이벌입니다.'
  *       404:
  *         description: 유저를 찾을 수 없음
  *         content:

--- a/src/routes/rivalRoutes.js
+++ b/src/routes/rivalRoutes.js
@@ -75,13 +75,21 @@ router.post('/register', async (req, res) => {
         const user = await User.findOne({ email: userEmail });
         const rival = await User.findOne({ nickname: rivalNickName });
 
-        if (!user || !rival) {
-            return res.status(404).json({ message: '유저를 찾을 수 없습니다.' });
-        }
+        if (!user || !rival) return res.status(404).json({ message: '유저를 찾을 수 없습니다.' });
+
+        const userAlreadyHasRival = user.rivals.includes(rival.email);
+        const rivalAlreadyHasUser = rival.rivals.includes(user.email);
+
+        if (userAlreadyHasRival && rivalAlreadyHasUser) return res.status(400).json({ message: '이미 등록된 라이벌입니다.' });
 
         if (!user.rivals.includes(rival.email)) {
             user.rivals.push(rival.email);
             await user.save();
+        }
+
+        if (!rival.rivals.includes(user.email)) {
+            rival.rivals.push(user.email);
+            await rival.save();
         }
 
         res.status(200).json({ message: '라이벌 등록 성공!', rivals: user.rivals });

--- a/src/routes/rivalRoutes.js
+++ b/src/routes/rivalRoutes.js
@@ -109,6 +109,65 @@ router.post('/register', async (req, res) => {
     }
 });
 
+/**
+ * @swagger
+ * /rival/remove?userEmail=${userEmail}&rivalNickname=${rivalNickname}:
+ *   delete:
+ *     summary: 라이벌 삭제
+ *     description: 사용자의 라이벌 목록에서 라이벌을 삭제합니다.
+ *     tags: [Rivals]
+ *     parameters:
+ *       - in: query
+ *         name: userEmail
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: 삭제 요청을 하는 유저의 이메일
+ *         example: 'user@example.com'
+ *       - in: query
+ *         name: rivalNickName
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: 삭제할 라이벌의 닉네임
+ *         example: 'rivalNickname'
+ *     responses:
+ *       200:
+ *         description: 라이벌 삭제 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: '라이벌 삭제 성공!'
+ *                 userRivals:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                     example: 'rival@example.com'
+ *       404:
+ *         description: 유저를 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: '유저를 찾을 수 없습니다.'
+ *       500:
+ *         description: 서버 에러
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: '서버 에러'
+ */
 router.delete('/remove', async (req, res) => {
     const { userEmail, rivalNickName } = req.query;
 

--- a/src/routes/rivalRoutes.js
+++ b/src/routes/rivalRoutes.js
@@ -173,7 +173,7 @@ router.delete('/remove', async (req, res) => {
 
     try {
         const user = await User.findOne({ email: userEmail });
-        const rival = await User.findOne({ nickname: rivalNickName });
+        const rival = await User.findOne({ nickName: rivalNickName });
 
         if (!user || !rival) return res.status(404).json({ message: '유저를 찾을 수 없습니다.' });
 

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -10,7 +10,7 @@ const User = require('../models/User');
  *     description: 닉네임을 사용하여 사용자를 검색합니다.
  *     tags: [User]
  *     parameters:
- *       - name: nickname
+ *       - name: nickName
  *         in: query
  *         required: true
  *         description: 검색할 닉네임
@@ -26,7 +26,7 @@ const User = require('../models/User');
  *               items:
  *                 type: object
  *                 properties:
- *                   nickname:
+ *                   nickName:
  *                     type: string
  *                   baekjoonTier:
  *                     type: string
@@ -39,13 +39,13 @@ const User = require('../models/User');
  */
 
 router.get('/search', async (req, res) => {
-    const { nickname } = req.query;
+    const { nickName } = req.query;
 
-    if (!nickname) return res.status(400).json({ message: '검색할 닉네임을 입력해주세요.' });
+    if (!nickName) return res.status(400).json({ message: '검색할 닉네임을 입력해주세요.' });
 
     try {
         const users = await User.find(
-            { nickname: { $regex: nickname, $options: 'i' } }
+            { nickName: { $regex: nickName, $options: 'i' } }
         ).select('-password -_id -__v -email');
 
         if (users.length === 0) return res.status(404).json({ message: '일치하는 사용자가 없습니다.' });

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -4,7 +4,7 @@ const User = require('../models/User');
 
 /**
  * @swagger
- * /users/search:
+ * /users/search?nickname={nickname}:
  *   get:
  *     summary: 사용자 검색
  *     description: 닉네임을 사용하여 사용자를 검색합니다.


### PR DESCRIPTION
## 작업 내용

- 라이벌 등록 성공 시 상대방의 rivals 배열에 내 이메일 추가
- 이미 등록된 라이벌이면 오류 메시지 보냄
- 라이벌 삭제
- nickname -> nickName ( 초반에 깜빡하고 카멜 케이스 못 맞춤 )

## 참고
- 라이벌 등록

![스크린샷 2024-09-26 오후 9 19 41](https://github.com/user-attachments/assets/08c583bf-4ad0-42a1-baf4-5ff7d896e62d)

- 등록 후 조회 ( body 내용은 필요없음 )

![스크린샷 2024-09-26 오후 9 20 05](https://github.com/user-attachments/assets/f4929619-9dbe-4057-95ce-694deb18a8f6)

- 등록 후 조회2 ( body 내용은 필요없음 )

![스크린샷 2024-09-26 오후 9 20 16](https://github.com/user-attachments/assets/73874def-b1b9-4ee0-be9a-dacd651a9ead)

- 이미 등록된 라이벌을 등록하려고 할 때

![스크린샷 2024-09-26 오후 9 24 11](https://github.com/user-attachments/assets/a4a5f0b4-6249-4205-9a35-3b2a786481b1)

- 라이벌 삭제

![스크린샷 2024-09-26 오후 9 50 43](https://github.com/user-attachments/assets/5602e050-c86b-48aa-b90e-98b3f7b52d6e)
