### PR TITLE
:bug: fix: Resolve double hashing password issue/16

### DIFF
--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const router = express.Router();
-const bcrypt = require('bcryptjs');
 const User = require('../models/User');
 const authMiddleware = require('../middlewares/authMiddleware');
 const { checkNickNameDuplicate } = require("../utils/validation");
@@ -169,8 +168,7 @@ router.put('/update-password', authMiddleware, async (req, res) => {
         const user = await User.findById(req.user.id);
         if (!user) return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
 
-        const salt = await bcrypt.genSalt(10);
-        user.password = await bcrypt.hash(newPassword, salt);
+        user.password = newPassword;
         await user.save();
 
         res.status(200).json({ message: '비밀번호가 성공적으로 변경되었습니다.' });


### PR DESCRIPTION
## 작업 내용

- 비밀 번호 변경 시에 비밀 번호를 해싱 작업을 하고 비밀 번호를 저장할 때도 해싱 작업을 하여 이중 해싱 작업이 일어남
- 그래서 로그인 할 때 바뀐 원본 비밀 번호를 알 수가 없음. -> 비밀 번호 변경 시에 해싱 작업 안 함.

## 참고
```
// 변경 전
const salt = await bcrypt.genSalt(10);
user.password = await bcrypt.hash(newPassword, salt);
// 변경 후
user.password = newPassword;
```
